### PR TITLE
Fix submission data model validation and gsheet rgb

### DIFF
--- a/src/pytanis/google.py
+++ b/src/pytanis/google.py
@@ -243,6 +243,7 @@ def mark_rows(worksheet, mask: pd.Series, color: ColorType):
     """
     rows = gsheet_rows_for_fmt(mask, worksheet.col_count)
     color_rgb = name_to_rgb(color) if isinstance(color, str) else color[:3]
+    color_rgb = [x / 255 for x in color_rgb]  # convert RGB to 0-1 range
     fmt = cellFormat(backgroundColor=Color(*color_rgb))
     if rows:
         format_cell_ranges(worksheet, [(rng, fmt) for rng in rows])

--- a/src/pytanis/pretalx/models.py
+++ b/src/pytanis/pretalx/models.py
@@ -90,10 +90,10 @@ class Speaker(SubmissionSpeaker):
 
 
 class Slot(BaseModel):
-    start: datetime | None
-    end: datetime | None
-    room: MultiLingualStr | None
-    room_id: int | None
+    start: datetime | None = None
+    end: datetime | None = None
+    room: MultiLingualStr | None = None
+    room_id: int | None = None
 
 
 class Resource(BaseModel):


### PR DESCRIPTION
- Fixed Pydantic Slot Model to conform with None definitions (set to default to make model_validate() work in case of None slot definition)
- Fixed RGB coloring for Gsheet API: Api changed and requires now normalised rgb values instead of common RGB definition