### PR TITLE
Get speaker avatar_url from API

### DIFF
--- a/src/pytanis/pretalx/models.py
+++ b/src/pytanis/pretalx/models.py
@@ -91,7 +91,7 @@ class SubmissionSpeaker(BaseModel):
     code: str
     name: str
     biography: str | None = None
-    avatar: str | None = None
+    avatar_url: str | None = None
     email: str | None = None
 
 


### PR DESCRIPTION
The field returned by the latest version of the API is `avatar_url`, not `avatar`.