### PR TITLE
API changes: submission gets a list of slots

### DIFF
--- a/src/pytanis/pretalx/models.py
+++ b/src/pytanis/pretalx/models.py
@@ -182,7 +182,7 @@ class Submission(BaseModel):
     duration: int | None = None
     do_not_record: bool
     is_featured: bool
-    slot: Slot | None = None  # only available after schedule_web release
+    slots: list[Slot] | None = None  # only available after schedule_web release
     slot_count: int
     image: str | None = None
     answers: list[Answer | int | Any] | None = None  # needs organizer permissions and `questions` query parameter


### PR DESCRIPTION
**WIP**

I noticed that the API returns multiple slots per Submission now.
I'm not sure if this is always true.

To not break existing code, we could assign slot to slots[0].
Unfortunately I cannot do it in the near future.
The example code and documentation should also be updated.